### PR TITLE
Upgrade to Go 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smallstep/linkedca
 
-go 1.25.0
+go 1.26.7
 
 require (
 	github.com/stretchr/testify v1.12.1


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from `1.25.0` to `1.26.7`, the latest 1.26 patch release available on the module proxy.

## Changes

- `go.mod`: `go 1.25.0` → `go 1.26.7`

That's the entire diff. No `toolchain` directive was needed, and `go.sum` is unchanged.

## `go fix`

Ran `go fix ./...` repeatedly until convergence — it reported **zero changes on the first pass**. Verified this wasn't a silent no-op:

- `go tool fix help` confirms all 23 fixers (`any`, `rangeint`, `minmax`, `newexpr`, `stringsseq`, `waitgroup`, …) are registered and enabled by default.
- `go fix -diff ./...` also produced empty output.

The repo has only five hand-written Go files (`policy.go`, `context.go`, `tools.go`, `policy_test.go`, `context_test.go`); everything else is generated `*.pb.go`, which `go fix` deliberately skips.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass under go1.26.7.

## Note on CI

`.github/workflows/ci.yml` delegates to `smallstep/workflows/.github/workflows/goCI.yml@main` with `only-latest-golang: false`, so the Go version is derived from `go.mod` rather than pinned in this repo — nothing to update there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)